### PR TITLE
モデルを、投稿文の判定を行い指定の型でレスポンスを返すように変更

### DIFF
--- a/back/src/agent/graph.py
+++ b/back/src/agent/graph.py
@@ -5,15 +5,36 @@ Returns a predefined response. Replace logic and configuration as needed.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, TypedDict
+from enum import Enum
+from typing import Any, Dict
 
 from dotenv import load_dotenv
-from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 from langgraph.graph import END, StateGraph
-from pydantic import Field
+from pydantic import BaseModel, Field
 
+
+class SafetyLevel(str, Enum):
+    """Safety level of the SNS post."""
+    SAFE = "safe"
+    WARNING = "warning"
+    DANGER = "danger"
+
+class SafetyCheckResult(BaseModel):
+    """SNS投稿の安全性チェック結果を表すモデル。."""
+    level: SafetyLevel = Field(
+        ...,
+        description="投稿内容の安全性レベル（safe: 安全, warning: 注意, danger: 危険）"
+    )
+    reason: str = Field(
+        ...,
+        description="安全性レベルを判定した理由の詳細な説明"
+    )
+    suggestion: str = Field(
+        ...,
+        description="投稿内容を改善するための具体的な提案"
+    ) 
 
 @dataclass
 class State:
@@ -23,8 +44,8 @@ class State:
     See: https://langchain-ai.github.io/langgraph/concepts/low_level/#state
     """
 
-    user_request: str = Field(..., description="ユーザーからのリクエスト")
-    response: str = Field(default="", description="AIからのレスポンス")
+    user_request: str = Field(..., description="ユーザーからのSNS投稿内容")
+    response: SafetyCheckResult = Field(default=None, description="AIからの安全性チェック結果")
 
 
 def call_model(state: State, llm: ChatOpenAI) -> Dict[str, Any]:
@@ -36,18 +57,28 @@ def call_model(state: State, llm: ChatOpenAI) -> Dict[str, Any]:
         [
             (
                 "system",
-                "あなたはユーザーインタビュー用の多様なペルソナを作成する専門家です。",
+                "あなたはSNS投稿の安全性をチェックする専門家です。\n"
+                "以下の基準に従って、投稿内容の安全性を評価してください：\n"
+                "1. 安全（safe）: 問題のない一般的な投稿\n"
+                "2. 注意（warning）: やや不適切な表現や内容が含まれる投稿\n"
+                "3. 危険（danger）: 明らかに不適切、有害、または違法な内容を含む投稿\n\n"
+                "評価結果は以下のJSON形式で返してください：\n"
+                "{{\n"
+                '    "level": "safe/warning/danger",\n'
+                '    "reason": "判定理由の詳細な説明",\n'
+                '    "suggestion": "改善提案"\n'
+                "}}",
             ),
             (
                 "human",
-                "ユーザーリクエスト: {user_request}\n\n",
+                "投稿内容: {user_request}",
             ),
         ]
     )
-    model = llm
-    output_parser = StrOutputParser()
-    chain = prompt | model | output_parser
-    result = chain.invoke({"user_request": state.user_request})
+    model = llm.with_structured_output(SafetyCheckResult)
+    chain = prompt | model
+    result: SafetyCheckResult = chain.invoke({"user_request": state.user_request})
+    
     return {
         "user_request": state.user_request,
         "response": result


### PR DESCRIPTION
## チケット
- #7 

## やったこと
- 投稿文の是非を判定するようにプロンプトを作成
- 投稿文の判定の結果の返り値の型を`SafetyCheckResult`クラスとして作成

## 確認方法
以下でグラフを起動し、投稿文を模したUserRequestに対して応答が適切か確認してください。
```shell
langgraph dev
```

## 備考
APIリクエストからモデルを呼び出す場合、下記で実行できます。
1. assistant idを取得
```shell
curl http://127.0.0.1:2024/assistants \
  --request POST \
  --header 'Content-Type: application/json' \
  --data '{
    "assistant_id": "",
    "graph_id": "agent",
    "config": {},
    "metadata": {},
    "if_exists": "raise",
    "name": "",
    "description": null
  }'
```

2. thredを作成
```shell
curl http://127.0.0.1:2024/threads \
  --request POST \
  --header 'Content-Type: application/json' \
  --data '{}'
```

3. thred内のアシスタントにリクエストを送る（実行が終わるまでレスポンスを待つ場合）
```shell
# thread_id, assistant_id, user_requestを置き換えてください
curl 'http://127.0.0.1:2024/threads/{thread_id}/runs/wait' \
  --request POST \
  --header 'Content-Type: application/json' \
  --data '{
    "assistant_id": {assistant_id},
    "input": {
      "user_request": {user_request}
    }
  }'
```

アプリで実行する際、1の処理はあらかじめ保持し、2を拡張機能をインストール時に実行し保持し、ユーザの投稿があった際に3を実行するという流れになると思います。