### PR TITLE
フロントとバックの連携

### DIFF
--- a/front/background.js
+++ b/front/background.js
@@ -1,7 +1,8 @@
 // 環境変数の設定
 const config = {
   API_URL: "http://127.0.0.1:2024",
-  ASSISTANT_ID: "c1ee8685-d317-4085-9bc9-11643e1e1df0"
+  // バックエンド起動のたび変更してください
+  ASSISTANT_ID: "df58dbc4-98ec-489a-a650-d1a120093703"
 };
 
 // 設定をストレージに保存

--- a/front/background.js
+++ b/front/background.js
@@ -1,0 +1,16 @@
+chrome.runtime.onInstalled.addListener(async () => {
+    const response = await fetch("http://127.0.0.1:2024/threads", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({})
+    });
+
+    const data = await response.json();
+    const threadId = data.thread_id;
+
+    // スレッドIDをストレージに保存
+    chrome.storage.local.set({ threadId });
+  });
+  

--- a/front/background.js
+++ b/front/background.js
@@ -1,5 +1,14 @@
+// 環境変数の設定
+const config = {
+  API_URL: "http://127.0.0.1:2024",
+  ASSISTANT_ID: "c1ee8685-d317-4085-9bc9-11643e1e1df0"
+};
+
+// 設定をストレージに保存
+chrome.storage.local.set({ config });
+
 chrome.runtime.onInstalled.addListener(async () => {
-    const response = await fetch("http://127.0.0.1:2024/threads", {
+    const response = await fetch(`${config.API_URL}/threads`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json"

--- a/front/content.js
+++ b/front/content.js
@@ -57,10 +57,24 @@ async function hookButton(selector) {
         }
 
         const data = await response.json();
-        console.log('Response data:', data);
+        const res = data.response
 
-        // レスポンスに基づいてポップアップを表示
-        showPopup(text + " リスクのある内容です。投稿を見直してください。");
+        // 判定の結果（safe, warning, danger）
+        const level = res.level;
+        // 訂正文
+        const corrected_text = res.corrected_text;
+        // 判断理由
+        const reason = res.reason;
+        // 投稿文におけるアドバイス
+        const suggestion = res.suggestion;
+
+        // TODO:levelがwarning, dangerで表示されるpopupのスタイルが分岐できるようにする
+        if (level != 'safe') {
+          // TODO:訂正案を別のpopupで表示できるようにする
+          showPopup("リスクのある内容です。投稿を見直してください。\n訂正案："+ corrected_text);
+        } else {
+          // TODO:安全な場合は本来の投稿処理を続行
+        }
       } catch (error) {
         console.error('Error:', error);
         showPopup("エラーが発生しました。もう一度お試しください。");

--- a/front/content.js
+++ b/front/content.js
@@ -26,7 +26,7 @@ async function hookButton(selector) {
   if (!existing) {
     return;
   }
-  const { threadId } = await chrome.storage.local.get("threadId");
+  const { threadId, config } = await chrome.storage.local.get(["threadId", "config"]);
   if (existing && !existing.dataset.hooked) {
     existing.dataset.hooked = "true";
 
@@ -39,13 +39,13 @@ async function hookButton(selector) {
       const text = editor?.innerText || "";
 
       try {
-        const response = await fetch(`http://127.0.0.1:2024/threads/${threadId}/runs/wait`, {
+        const response = await fetch(`${config.API_URL}/threads/${threadId}/runs/wait`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json"
           },
           body: JSON.stringify({
-            assistant_id: "c1ee8685-d317-4085-9bc9-11643e1e1df0",
+            assistant_id: config.ASSISTANT_ID,
             input: {
               user_request: text
             }


### PR DESCRIPTION
## チケット
- #9 

## やったこと
- `back/`のエージェントにリクエストを送れるように、`front/`の実装
  - インストール時に`thread`の作成
  - Xでのメッセージの送信時に、バックに投稿可否のリクエストを送信できるように実装
  - エージェントからのレスポンスを変数に格納して、表示の分岐ができるように実装

## 確認方法
1. バックの起動
```
langgraph dev
```
2. 拡張機能のインストール
3. Xで少し不適切な文章を書き、投稿時に訂正文が表示されることを確認

https://github.com/user-attachments/assets/9ac92481-f108-4323-b43c-907deb04832f

